### PR TITLE
Allow for encrypted command data

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -525,6 +525,11 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         }
 
         if (isset($currentPayload['data']['command'])) {
+            // If the command data is encrypted, decrypt it first before attempting to unserialize
+            if (in_array(ShouldBeEncrypted::class, class_implements($currentPayload['data']['commandName']))) {
+                $currentPayload['data']['command'] = decrypt($currentPayload['data']['command']);
+            }
+            
             $commandData = unserialize($currentPayload['data']['command']);
             if (property_exists($commandData, 'priority')) {
                 $properties['priority'] = $commandData->priority;


### PR DESCRIPTION
If a Laravel Job implements `ShouldBeEncrypted`, when dispatching it to RabbitMQ via this package throws the following error:

`NOTICE  unserialize(): Error at offset 0 of 17380 bytes in vendor/vladimir-yuldashev/laravel-queue-rabbitmq/src/Queue/RabbitMQQueue.php on line 528.`

Added a bugfix to handle fetching priority from encrypted command data if the job class implements `ShouldBeEncrypted`